### PR TITLE
connected artist hook to artist card

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import useGenres from "@/hooks/useGenres";
 import useArtist from "@/hooks/useArtist";
 import ArtistsForceGraph from "@/components/ArtistsForceGraph";
 import GenresForceGraph from "@/components/GenresForceGraph";
-import {BasicNode} from "@/types";
+import {Artist, BasicNode} from "@/types";
 import { motion, AnimatePresence } from "framer-motion";
 import { ResetButton } from "@/components/ResetButton";
 import { ListViewPanel } from "@/components/ListViewPanel";
@@ -20,13 +20,20 @@ import { ArtistCard } from './components/ArtistCard'
 function App() {
   // App state for selected genre and artist
   const [selectedGenre, setSelectedGenre] = useState<string | undefined>(undefined);
-  const [selectedArtist, setSelectedArtist] = useState<BasicNode | undefined>(undefined);
+  const [selectedArtist, setSelectedArtist] = useState<Artist | undefined>(undefined);
   const { genres, genreLinks, genresLoading, genresError } = useGenres();
   const { artists, artistLinks, artistsLoading, artistsError } = useGenreArtists(selectedGenre);
   const { artistData, artistLoading, artistError } = useArtist(selectedArtist?.id);
   const [showListView, setShowListView] = useState(false);
   const [showArtistCard, setShowArtistCard] = useState(false)
   const isMobile = useMediaQuery({ maxWidth: 640 });
+
+  const setArtistFromName = (name: string) => {
+    const artist = artists.find((artist) => artist.name === name);
+    if (artist) {
+      setSelectedArtist(artist);
+    }
+  }
   console.log("App render", {
   selectedGenre,
   selectedArtist,
@@ -102,9 +109,11 @@ function App() {
           </div>
           <ArtistCard
               selectedArtist={selectedArtist}
-              setSelectedArtist={setSelectedArtist}
+              setSelectedArtist={setArtistFromName}
               artistData={artistData}
-             />
+              artistLoading={artistLoading}
+              artistError={artistError}
+          />
         </div>
 
   </>

--- a/src/components/ArtistCard.tsx
+++ b/src/components/ArtistCard.tsx
@@ -1,76 +1,89 @@
-import { BasicNode } from '@/types'
+import {Artist, BasicNode} from '@/types'
 import { LastFMArtistJSON } from '@/types';
 import { motion, AnimatePresence } from "framer-motion";
 import { dummyLastFMArtistData } from '@/DummyDataForDummies'
 import { X } from "lucide-react"
-import { formatDate } from '@/lib/utils'
+import {formatDate, formatNumber} from '@/lib/utils'
+import {Loading} from "@/components/Loading";
+import {AxiosError} from "axios";
 
 interface ArtistCardProps {
-    selectedArtist?: BasicNode;
-    setSelectedArtist: (artist: BasicNode | undefined) => void;
+    selectedArtist?: Artist;
+    setSelectedArtist: (artist: string) => void;
     artistData?: LastFMArtistJSON;
-    }
-
-const artist = dummyLastFMArtistData[0]
-
+    artistLoading: boolean;
+    artistError?: AxiosError;
+}
 
 export function ArtistCard({
     selectedArtist,
     setSelectedArtist,
-    artistData
-
+    artistData,
+    artistLoading,
+    artistError,
 }: ArtistCardProps) {
-    if (!selectedArtist) return null
-    return (
+    return (!selectedArtist || !artistData) ? null : (
      <AnimatePresence mode="wait">
-            
-              <motion.div
-         initial={{ opacity: 0, y:3}}
-         animate={{ opacity: 1, y:0}}
-         exit={{ opacity: 0, y:3}}
-         transition={{ duration: 0.4, ease: "easeOut" }}
-         className='
-         w-[420px] h-auto p-3 z-50 pb-4
-         flex items-start gap-3
-         bg-background rounded-3xl border border-gray-200
-         '
-             >
-         <div className="
-         w-24 h-full overflow-hidden
-         rounded-lg border border-gray-100
-         ">
-             <img
-             className="w-full h-full object-cover"
-             src={artist?.image[0].link}
-             alt={artist?.name}
-             />
-         </div>
-         <div className='flex flex-col items-start gap-1'>
-         <div>
-             <h2 className="text-md font-semibold w-full max-h-[20px] truncate">{selectedArtist.name}</h2>
-             {/* <h3 className="text-sm"> {formatNumber(artist.stats.listeners)} listeners
-             </h3> */}
-         </div>
-                 <div className="
-                 flex flex-col
-                 text-sm text-muted-foreground
-                 ">
-                     <p>Founded {artist?.date ? formatDate(artist.date) : 'Unknown'} </p>
-                     {/* <p>{artist?.bio?.content}</p> */}
-                 <p>
-                     Similar to {artist?.similar?.slice(0, 3).map((name, index, array) => (
-                        <>
-                             <button key={name}>
-                                 {name}
-                             </button>
-                             {index < array.length - 1 ? ', ' : ''}
-                        </>
-                     ))}
-                     
-                 </p>
-                 </div>
-         </div>
-             </motion.div>
+         <motion.div
+             initial={{ opacity: 0, y:3}}
+             animate={{ opacity: 1, y:0}}
+             exit={{ opacity: 0, y:3}}
+             transition={{ duration: 0.4, ease: "easeOut" }}
+             className='
+             w-[420px] h-auto p-3 z-50 pb-4
+             flex items-start gap-3
+             bg-background rounded-3xl border border-gray-200
+             '
+         >
+             {artistLoading ? (
+                 <Loading />
+             ) : (
+                 <>
+                     <div className="
+                         w-24 h-full overflow-hidden
+                         rounded-lg border border-gray-100
+                     ">
+                         <img
+                             className="w-full h-full object-cover"
+                             src={artistData.image[0].link}
+                             alt={artistData.name}
+                         />
+                     </div>
+                     {artistError ? <p>No last.fm data found for {selectedArtist.name}</p> : (
+                         <div className='flex flex-col items-start gap-1'>
+                             <div>
+                                 <h2 className="text-md font-semibold w-full max-h-[20px] truncate">{artistData.name}</h2>
+                                 {artistData.stats.listeners && (
+                                     <h3 className="text-sm"> {formatNumber(artistData.stats.listeners)} listeners
+                                     </h3>
+                                 )}
+                             </div>
+                             <div className="
+                             flex flex-col
+                             text-sm text-muted-foreground
+                         ">
+                                 <p>Founded {selectedArtist.startDate ? formatDate(selectedArtist.startDate) : 'Unknown'} </p>
+                                 <p>{artistData.bio ? artistData.bio.summary : 'No bio'}</p>
+
+                                 {artistData.similar && (
+                                     <p>
+                                         Similar to {artistData.similar.slice(0, 3).map((name, index, array) => (
+                                         <>
+                                             <button key={name} onClick={() => setSelectedArtist(name)}>
+                                                 {name}
+                                             </button>
+                                             {index < array.length - 1 ? ', ' : ''}
+                                         </>
+                                     ))}
+                                     </p>
+                                 )}
+                             </div>
+                         </div>
+                     )}
+
+                 </>
+             )}
+         </motion.div>
      </AnimatePresence>
     )
 }

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -7,19 +7,17 @@ import { Loading } from "./Loading";
 interface ArtistsForceGraphProps {
     artists: Artist[];
     artistLinks: NodeLink[];
-    onNodeClick: (artist: BasicNode) => void;
+    onNodeClick: (artist: Artist) => void;
     loading: boolean;
 }
 
 const ArtistsForceGraph: React.FC<ArtistsForceGraphProps> = ({artists, artistLinks, onNodeClick, loading}) => {
-    const [graphData, setGraphData] = useState<GraphData>({ nodes: [], links: [] });
+    const [graphData, setGraphData] = useState<GraphData<Artist, NodeLink>>({ nodes: [], links: [] });
     useEffect(() => {
         if (artists && artistLinks) {
             setGraphData(
                 {
-                    nodes: artists.map(artist => {
-                        return {id: artist.id, name: artist.name}
-                    }),
+                    nodes: artists,
                     links: artistLinks
                 }
             );
@@ -35,7 +33,7 @@ const ArtistsForceGraph: React.FC<ArtistsForceGraphProps> = ({artists, artistLin
             linkVisibility={true}
             linkColor='#666666'
             linkCurvature={0.2}
-            onNodeClick={node => onNodeClick({ id: node.id ? node.id.toString() : 'no id', name: node.name })}
+            onNodeClick={onNodeClick}
             nodeCanvasObject={(node, ctx, globalScale) => {
                 const label = node.name;
                 const fontSize = 12/globalScale;

--- a/src/components/BreadcrumbHeader.tsx
+++ b/src/components/BreadcrumbHeader.tsx
@@ -1,14 +1,14 @@
 import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator } from './ui/breadcrumb'
 import { LucideIcon, ChevronDown, ChevronUp } from 'lucide-react'
-import { BasicNode } from '@/types'
+import {Artist, BasicNode} from '@/types'
 import { Button } from "@/components/ui/button"
 import useGenres from "@/hooks/useGenres";
 
 interface BreadcrumbHeaderProps {
     selectedGenre: string | undefined
     setSelectedGenre: (genre: string | undefined) => void
-    selectedArtist: BasicNode | undefined
-    setSelectedArtist: (artist: BasicNode | undefined) => void
+    selectedArtist: Artist | undefined
+    setSelectedArtist: (artist: Artist | undefined) => void
     HomeIcon: LucideIcon
     toggleListView: () => void
     showListView: boolean

--- a/src/hooks/useArtist.tsx
+++ b/src/hooks/useArtist.tsx
@@ -15,6 +15,7 @@ const useArtist = (mbid?: string) => {
             try {
                 const response = await axios.get(`${url}${mbid}`);
                 setArtistData(response.data);
+                setArtistError(undefined);
             } catch (err) {
                 if (err instanceof AxiosError) {
                     setArtistError(err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface LastFMArtistJSON {
     stats: LastFMStats;
     bio: LastFMBio;
     similar: string[];
-    date: string;
+    date: string; // this is for caching
 }
 
 export interface LastFMImage {


### PR DESCRIPTION
Added basic functionality for artist card. 

Issues:
- last.fm image links seem to all just be a little star? this is on their end
- should be able to close artist card
- a lot of artists aren't on last.fm, or at least their mbid isn't
- bios need some formatting (can do this on backend)
- long artist names make the bio text go outside the card
- similar artists might not be in the genre (will have to filter these out)